### PR TITLE
Supporting IStubElementType and StubBasedPsiElement.

### DIFF
--- a/src/main/java/org/antlr/jetbrains/adapter/lexer/PsiElementTypeFactory.java
+++ b/src/main/java/org/antlr/jetbrains/adapter/lexer/PsiElementTypeFactory.java
@@ -1,5 +1,6 @@
 package org.antlr.jetbrains.adapter.lexer;
 
+import com.google.common.base.Preconditions;
 import com.intellij.lang.Language;
 import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.tree.TokenSet;
@@ -108,7 +109,8 @@ public class PsiElementTypeFactory {
             elementTypes[i] = new RuleIElementTypeImpl(i, ruleNames[i], language);
         }
         for (RuleIElementType customType : customRuleElementTypes) {
-            assert customType instanceof IElementType;
+            Preconditions.checkArgument(customType instanceof IElementType,
+                    "Custom rule element types should extend IElementType.");
             elementTypes[customType.getRuleIndex()] = customType;
         }
         result = Collections.unmodifiableList(Arrays.asList(elementTypes));

--- a/src/main/java/org/antlr/jetbrains/adapter/lexer/PsiElementTypeFactory.java
+++ b/src/main/java/org/antlr/jetbrains/adapter/lexer/PsiElementTypeFactory.java
@@ -41,13 +41,12 @@ public class PsiElementTypeFactory {
         eofIElementType = new TokenIElementType(Token.EOF, "EOF", language);
     }
 
-    public static PsiElementTypeFactory create(Language language, Parser parser) {
-        return create(language, parser, new ArrayList<>());
+    public static Builder builder() {
+        return new Builder();
     }
 
-    public static PsiElementTypeFactory create(Language language, Parser parser,
-            Collection<RuleIElementType> customRuleElementTypes) {
-        return new PsiElementTypeFactory(language, parser, customRuleElementTypes);
+    public static PsiElementTypeFactory create(Language language, Parser parser) {
+        return new PsiElementTypeFactory(language, parser, new ArrayList<>());
     }
 
     public TokenIElementType getEofElementType() {
@@ -130,5 +129,38 @@ public class PsiElementTypeFactory {
             }
         }
         return TokenSet.create(elementTypes);
+    }
+
+    /**
+     * Builder for [PsiElementFactory].
+     */
+    public static final class Builder {
+
+        private final Collection<RuleIElementType> customElementTypes = new ArrayList<>();
+        private Language language;
+        private Parser parser;
+
+        Builder() {
+        }
+
+        public Builder language(Language language) {
+            this.language = language;
+            return this;
+        }
+
+        public Builder parser(Parser parser) {
+            this.parser = parser;
+            return this;
+        }
+
+        public <T extends IElementType & RuleIElementType> Builder addRuleElementType(
+                T elementType) {
+            customElementTypes.add(elementType);
+            return this;
+        }
+
+        public PsiElementTypeFactory build() {
+            return new PsiElementTypeFactory(language, parser, customElementTypes);
+        }
     }
 }

--- a/src/main/java/org/antlr/jetbrains/adapter/lexer/PsiElementTypeFactory.java
+++ b/src/main/java/org/antlr/jetbrains/adapter/lexer/PsiElementTypeFactory.java
@@ -103,18 +103,16 @@ public class PsiElementTypeFactory {
     @NotNull
     private List<RuleIElementType> createRuleIElementTypes(Language language, String[] ruleNames,
             Collection<RuleIElementType> customRuleElementTypes) {
-        List<RuleIElementType> result;
-        RuleIElementType[] elementTypes = new RuleIElementTypeImpl[ruleNames.length];
+        List<RuleIElementType> elementTypes = new ArrayList<>();
         for (int i = 0; i < ruleNames.length; i++) {
-            elementTypes[i] = new RuleIElementTypeImpl(i, ruleNames[i], language);
+            elementTypes.add(new RuleIElementTypeImpl(i, ruleNames[i], language));
         }
         for (RuleIElementType customType : customRuleElementTypes) {
             Preconditions.checkArgument(customType instanceof IElementType,
                     "Custom rule element types should extend IElementType.");
-            elementTypes[customType.getRuleIndex()] = customType;
+            elementTypes.set(customType.getRuleIndex(), customType);
         }
-        result = Collections.unmodifiableList(Arrays.asList(elementTypes));
-        return result;
+        return Collections.unmodifiableList(elementTypes);
     }
 
     /**

--- a/src/main/java/org/antlr/jetbrains/adapter/lexer/RuleIElementType.java
+++ b/src/main/java/org/antlr/jetbrains/adapter/lexer/RuleIElementType.java
@@ -1,11 +1,5 @@
 package org.antlr.jetbrains.adapter.lexer;
 
-import com.intellij.lang.Language;
-import com.intellij.psi.tree.IElementType;
-import org.jetbrains.annotations.NonNls;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
 /**
  * Represents a specific ANTLR rule invocation in the language of the plug-in and is the
  * intellij "token type" of an interior PSI tree node. The IntelliJ equivalent
@@ -15,17 +9,7 @@ import org.jetbrains.annotations.Nullable;
  * We differentiate between parse tree subtree roots and tokens with
  * {@link RuleIElementType} and {@link TokenIElementType}.
  */
-public class RuleIElementType extends IElementType {
-    private final int ruleIndex;
+public interface RuleIElementType {
 
-    public RuleIElementType(int ruleIndex,
-                            @NotNull @NonNls String debugName,
-                            @Nullable Language language) {
-        super(debugName, language);
-        this.ruleIndex = ruleIndex;
-    }
-
-    public int getRuleIndex() {
-        return ruleIndex;
-    }
+    int getRuleIndex();
 }

--- a/src/main/java/org/antlr/jetbrains/adapter/lexer/RuleIElementTypeImpl.java
+++ b/src/main/java/org/antlr/jetbrains/adapter/lexer/RuleIElementTypeImpl.java
@@ -1,0 +1,26 @@
+package org.antlr.jetbrains.adapter.lexer;
+
+import com.intellij.lang.Language;
+import com.intellij.psi.tree.IElementType;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Implementation of [RuleIElementType] based on [IElementType].
+ */
+public class RuleIElementTypeImpl extends IElementType implements RuleIElementType {
+
+    private final int ruleIndex;
+
+    public RuleIElementTypeImpl(int ruleIndex,
+            @NotNull @NonNls String debugName,
+            @Nullable Language language) {
+        super(debugName, language);
+        this.ruleIndex = ruleIndex;
+    }
+
+    public int getRuleIndex() {
+        return ruleIndex;
+    }
+}

--- a/src/main/java/org/antlr/jetbrains/adapter/lexer/RuleIStubElementTypeImpl.java
+++ b/src/main/java/org/antlr/jetbrains/adapter/lexer/RuleIStubElementTypeImpl.java
@@ -1,0 +1,29 @@
+package org.antlr.jetbrains.adapter.lexer;
+
+import com.intellij.lang.Language;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.stubs.IStubElementType;
+import com.intellij.psi.stubs.StubElement;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Implementation of [RuleIElementType] based on [IStubElementType].
+ */
+public abstract class RuleIStubElementTypeImpl<StubT extends StubElement, PsiT extends PsiElement> extends
+        IStubElementType<StubT, PsiT> implements RuleIElementType {
+
+    private final int ruleIndex;
+
+    public RuleIStubElementTypeImpl(int ruleIndex,
+            @NotNull @NonNls String debugName,
+            @Nullable Language language) {
+        super(debugName, language);
+        this.ruleIndex = ruleIndex;
+    }
+
+    public int getRuleIndex() {
+        return ruleIndex;
+    }
+}

--- a/src/main/java/org/antlr/jetbrains/adapter/parser/AntlrParseTreeToPsiConverter.java
+++ b/src/main/java/org/antlr/jetbrains/adapter/parser/AntlrParseTreeToPsiConverter.java
@@ -3,6 +3,7 @@ package org.antlr.jetbrains.adapter.parser;
 import com.intellij.lang.Language;
 import com.intellij.lang.PsiBuilder;
 import com.intellij.openapi.progress.ProgressIndicatorProvider;
+import com.intellij.psi.tree.IElementType;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashMap;
@@ -183,7 +184,7 @@ public class AntlrParseTreeToPsiConverter implements ParseTreeListener {
                 marker.error("syntax error");
             }
         } else {
-            marker.done(getRuleElementTypes().get(ctx.getRuleIndex()));
+            marker.done((IElementType) getRuleElementTypes().get(ctx.getRuleIndex()));
         }
     }
 }

--- a/src/main/java/org/antlr/jetbrains/adapter/psi/AntlrPsiNode.java
+++ b/src/main/java/org/antlr/jetbrains/adapter/psi/AntlrPsiNode.java
@@ -9,7 +9,7 @@ import org.antlr.jetbrains.adapter.lexer.TokenIElementType;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * This class represents an internal, non-leaf "composite" PSI
+ * A base class for an internal, non-leaf "composite" PSI
  * node. The term "AntlrPsiNode" is somewhat of a misnomer as it's
  * really just a PSI node but make sure that getChildren() acts as I
  * would expect, returning all children.

--- a/src/main/java/org/antlr/jetbrains/adapter/psi/AntlrStubBasedPsiNode.java
+++ b/src/main/java/org/antlr/jetbrains/adapter/psi/AntlrStubBasedPsiNode.java
@@ -1,0 +1,58 @@
+package org.antlr.jetbrains.adapter.psi;
+
+import com.intellij.extapi.psi.StubBasedPsiElementBase;
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.stubs.IStubElementType;
+import com.intellij.psi.stubs.StubElement;
+import com.intellij.psi.tree.IElementType;
+import org.antlr.jetbrains.adapter.SymtabUtils;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * An equivalent of [AntlrPsiNode] for stub based PsiElements.
+ */
+public abstract class AntlrStubBasedPsiNode<T extends StubElement> extends
+        StubBasedPsiElementBase<T> {
+
+    public AntlrStubBasedPsiNode(@NotNull ASTNode node) {
+        super(node);
+    }
+
+    public AntlrStubBasedPsiNode(T stub, IStubElementType type) {
+        super(stub, type);
+    }
+
+    public AntlrStubBasedPsiNode(T stub, IElementType type, ASTNode node) {
+        super(stub, type, node);
+    }
+
+    /**
+     * For some reason, default impl of this only returns rule refs
+     * (composite nodes in jetbrains speak) but we want ALL children.
+     * Well, we don't want hidden channel stuff.
+     */
+    @Override
+    @NotNull
+    public PsiElement[] getChildren() {
+        return Trees.getChildren(this);
+    }
+
+    /**
+     * For this internal PSI node, look upward for our enclosing scope.
+     * Start looking for a scope at our parent node so getContext()
+     * returns the enclosing scope (context) when this is a ScopeNode.
+     * <p>
+     * From the return to scope node, you typically look for a declaration
+     * by looking at its children.
+     */
+    @Override
+    public ScopeNode getContext() {
+        return SymtabUtils.getContextFor(this);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "(" + getNode().getElementType().toString() + ")";
+    }
+}

--- a/src/main/java/org/antlr/jetbrains/adapter/psi/AntlrStubBasedPsiNode.java
+++ b/src/main/java/org/antlr/jetbrains/adapter/psi/AntlrStubBasedPsiNode.java
@@ -3,6 +3,7 @@ package org.antlr.jetbrains.adapter.psi;
 import com.intellij.extapi.psi.StubBasedPsiElementBase;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.StubBasedPsiElement;
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.stubs.StubElement;
 import com.intellij.psi.tree.IElementType;
@@ -13,7 +14,7 @@ import org.jetbrains.annotations.NotNull;
  * An equivalent of [AntlrPsiNode] for stub based PsiElements.
  */
 public abstract class AntlrStubBasedPsiNode<T extends StubElement> extends
-        StubBasedPsiElementBase<T> {
+        StubBasedPsiElementBase<T> implements StubBasedPsiElement<T> {
 
     public AntlrStubBasedPsiNode(@NotNull ASTNode node) {
         super(node);

--- a/src/main/java/org/antlr/jetbrains/adapter/psi/Trees.java
+++ b/src/main/java/org/antlr/jetbrains/adapter/psi/Trees.java
@@ -96,9 +96,9 @@ public class Trees {
         return false;
     }
 
-    public static AntlrPsiNode getRoot(PsiElement t) {
+    public static PsiElement getRoot(PsiElement t) {
         PsiFile contextOfType = PsiTreeUtil.getParentOfType(t, PsiFile.class);
-        return (AntlrPsiNode) Trees.getChildren(contextOfType)[0];
+        return Trees.getChildren(contextOfType)[0];
     }
 
     /**
@@ -133,18 +133,16 @@ public class Trees {
 
     private static void findAllNodesImpl(PsiElement t, int index, boolean findTokens,
                                          List<? super PsiElement> nodes) {
+        IElementType elType = t.getNode().getElementType();
+
         // check this node (the root) first
         if (findTokens && t instanceof LeafPsiElement) {
-            LeafPsiElement tnode = (LeafPsiElement) t;
-            IElementType elType = tnode.getNode().getElementType();
             if (elType instanceof TokenIElementType) {
                 if (((TokenIElementType) elType).getAntlrTokenType() == index) {
                     nodes.add(t);
                 }
             }
-        } else if (!findTokens && t instanceof AntlrPsiNode) {
-            AntlrPsiNode ctx = (AntlrPsiNode) t;
-            IElementType elType = ctx.getNode().getElementType();
+        } else if (!findTokens && !(t instanceof LeafPsiElement)) {
             if (elType instanceof RuleIElementType) {
                 if (((RuleIElementType) elType).getRuleIndex() == index) {
                     nodes.add(t);


### PR DESCRIPTION
1. Allowing custom RuleIElementTypes in PsiElementTypeFactory.
2. Converting RuleIElementType to a thin interface with stub-based and not stub-based implementations.
3. Introducing AntlrStubBasedPsiNode, a base class for stub-based PsiElements.

Broken assumptions:
1. RuleIElementType is not a descendant of IElementType anymore.
2. Not all non-leaf elements are instances of AntlrPsiNode anymore (they might be AntlrStubBasedPsiNodes), their common interface is now PsiElement.